### PR TITLE
Feat: Support for service provider place registration for search functionality

### DIFF
--- a/src/main/java/com/bookmysport/authentication_service/Controllers/MainController.java
+++ b/src/main/java/com/bookmysport/authentication_service/Controllers/MainController.java
@@ -1,5 +1,9 @@
 package com.bookmysport.authentication_service.Controllers;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -14,6 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bookmysport.authentication_service.Models.LoginModel;
 import com.bookmysport.authentication_service.Models.ResponseMessage;
 import com.bookmysport.authentication_service.Models.ServiceProviderModel;
+import com.bookmysport.authentication_service.Repository.ServiceProviderRepository;
+import com.bookmysport.authentication_service.SearchFunction.SearchByAddressAndCentreName;
 import com.bookmysport.authentication_service.UserServices.ArenaDetailsUpdateService;
 import com.bookmysport.authentication_service.UserServices.UserService;
 
@@ -28,6 +34,12 @@ public class MainController {
 
     @Autowired
     private ArenaDetailsUpdateService arenaDetailsUpdateService;
+
+    @Autowired
+    private SearchByAddressAndCentreName searchByAddressAndCentreName;
+
+    @Autowired
+    private ServiceProviderRepository serviceProviderRepository;
 
     @PostMapping("adduser")
     public ResponseEntity<Object> addUser(@Valid @RequestBody Object userOrService, BindingResult bindingResult,@RequestHeader String role) {
@@ -69,6 +81,18 @@ public class MainController {
     public ResponseEntity<ResponseMessage> updateArenaDetails(@RequestHeader String token,@RequestBody ServiceProviderModel latestDetails)
     {
         return arenaDetailsUpdateService.playGroundDetailsUpdateService(token, latestDetails);
+    }
+
+    @GetMapping("searchbyaddressandcentrename")
+    public List<ServiceProviderModel> searchFunction(@RequestHeader String searchItem)
+    {
+        return searchByAddressAndCentreName.searchByAddressAndCentreNameService(searchItem);
+    }
+
+    @GetMapping("getdetailsbyspid")
+    public Optional<ServiceProviderModel> getDetailsBySpId(@RequestHeader String spId)
+    {
+        return serviceProviderRepository.findById(UUID.fromString(spId));
     }
 
 }

--- a/src/main/java/com/bookmysport/authentication_service/Repository/ServiceProviderRepository.java
+++ b/src/main/java/com/bookmysport/authentication_service/Repository/ServiceProviderRepository.java
@@ -1,11 +1,22 @@
 package com.bookmysport.authentication_service.Repository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.bookmysport.authentication_service.Models.ServiceProviderModel;
+import jakarta.transaction.Transactional;
 
 public interface ServiceProviderRepository extends JpaRepository<ServiceProviderModel, UUID> {
     ServiceProviderModel findByEmail(String email);
+
+    @Transactional
+    @Query(value = "SELECT * FROM service_provider_details WHERE address like %?1% or centre_name like %?1%", nativeQuery = true)
+    List<ServiceProviderModel> findByAddressAndCentreName(String search);
+
+    @SuppressWarnings("null")
+    Optional<ServiceProviderModel> findById(UUID id);
 }

--- a/src/main/java/com/bookmysport/authentication_service/SearchFunction/SearchByAddressAndCentreName.java
+++ b/src/main/java/com/bookmysport/authentication_service/SearchFunction/SearchByAddressAndCentreName.java
@@ -1,0 +1,21 @@
+package com.bookmysport.authentication_service.SearchFunction;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.bookmysport.authentication_service.Models.ServiceProviderModel;
+import com.bookmysport.authentication_service.Repository.ServiceProviderRepository;
+
+@Service
+public class SearchByAddressAndCentreName {
+
+    @Autowired
+    private ServiceProviderRepository serviceProviderRepository;
+
+    public List<ServiceProviderModel> searchByAddressAndCentreNameService(String searchItem) {
+        List<ServiceProviderModel> searchResults = serviceProviderRepository.findByAddressAndCentreName(searchItem);
+        return searchResults;
+    }
+}


### PR DESCRIPTION
In this PR I have add some files and API-endpoints where a user can search the resources by any of the following.

Users can search by:

1. Centre name
2. Address of the playground
3. Sport name

The entire implementation is done in Service provider place registration repository. Here I have implemented the API-endpoints so that the service provider place registration repository can communicate and fetch the information from this repository.

Information fetched from Service provider place registration repository from Authentication service are:

1. Information when the search item contains the part of the address or the centre name
2. Information about the service provider ID and return the address and centre name in accordance with it.

You can check the usage of the end-points here: https://github.com/BookMySport-com-Platform/Service-Provider-Place-Registration/pull/9